### PR TITLE
Reset Keybind Editor

### DIFF
--- a/Libraries/BootstrapMenu.js
+++ b/Libraries/BootstrapMenu.js
@@ -50,6 +50,14 @@ window.BootstrapMenu.make = function () {
         }
     }
 
+    window.ShowResetKey = function () {
+        if(document.getElementById('reset-key').style.display === 'inline-block'){
+            document.getElementById('reset-key').style.display = "none";
+        }else{
+            document.getElementById('reset-key').style.display = "inline-block";
+        }
+    }
+
     window.BootstrapSetup = function () {
 
         const a = new Image();
@@ -187,6 +195,25 @@ window.BootstrapMenu.make = function () {
     <option value="5">Onion</option>
   </select>
   <br>
+</div>
+  <button class="btn" style="margin:3px;color:white;background-color:#1155CC;font-family:Roboto,Arial,sans-serif;" id="ResetKeybind">Edit Reset Keybind</button><br>
+  <div id="reset-key" style="
+      display:none;
+      padding:3px 6px;
+      border-radius:0;
+      border:4px solid #000000;
+      background: #ffffff;
+      color:#000000;
+      font-family:Roboto,Arial,sans-serif;
+      font-size:1.2vh;
+      cursor:pointer;
+      user-select:none;
+      transition:all 0.2s ease;
+      margin-left:5px;
+    ">None</div>
+    </br>
+
+    </div>
 
 <select style="display:none;margin:3px;background-color:#1155CC;color:white;font-family:Roboto,Arial,sans-serif; align-items: center; text-align: center;" id="snakePride" class="form-control flex-row">
   <option value="0">Default Rainbow</option>
@@ -253,6 +280,32 @@ window.BootstrapMenu.make = function () {
         scrollbtn_checkbox.addEventListener("change", window.ToggleScrollbar);
         scrollbtn_checkbox.checked = window.pudding_settings.ScrollBar;
 
+        keybind_settings = document.getElementById("ResetKeybind"); // keybind changer
+        keybind_settings.addEventListener("click", window.ShowResetKey);
+
+        // Code for reset key
+        let keybinds = JSON.parse(localStorage.getItem("keybinds")) || {};
+        function setupKeybindPicker(id, keybindType) {
+            const box = document.getElementById(id);
+            if(!keybinds[keybindType]){
+                keybinds[keybindType] = "Shift";
+            }
+            box.textContent = keybinds[keybindType];
+
+            box.addEventListener("click", () => {
+                box.textContent = "Press any key...";
+                document.addEventListener("keydown", function handler(e) {
+                keybinds[keybindType] = e.key;
+                box.textContent = e.key;
+                localStorage.setItem("keybinds", JSON.stringify(keybinds));
+                document.removeEventListener("keydown", handler);
+                });
+            });
+        }
+
+        // Apply to each bind
+        setupKeybindPicker("reset-key", "resetKey");
+
         if (window.pudding_settings.ScrollBar) {
             // Disable it
             document.body.style.overflow = 'hidden';
@@ -267,8 +320,10 @@ window.BootstrapMenu.make = function () {
             EatThemeRandomizer2.style.display = 'none';
             EatThemeRandomizer.checked = false;
             window.pudding_settings.randomizeThemeApple = false;
+            EatThemeRandomizer.parentElement.style.display = 'none';
         } else
         {
+            EatThemeRandomizer.parentElement.style.display = 'block';
             console.log("Disabling SpeedInfo")
             speedinfo_checkbox.disabled = true;
             speedinfo_checkbox.checked = false;

--- a/PuddingInit.js
+++ b/PuddingInit.js
@@ -109,14 +109,18 @@ window.PuddingMod.alterSnakeCode = function (code) {
 
   // Make it so Shift + Esc resets the game
   document.addEventListener('keydown', function(e){
-    if(e.key === "Shift"){
-        const keydownEvent = new KeyboardEvent('keydown', {
-            keyCode: 27
-        });
-        document.dispatchEvent(keydownEvent);
-        document.querySelector('[jsname="NSjDf"]').click();
+    let keybinds = JSON.parse(localStorage.getItem("keybinds")) || {};
+    if(!(document.getElementById('reset-key').style.display === 'inline-block' || window.timeKeeper.dialogActive || document.getElementById('edit-box'))){
+        if(e.key === keybinds["resetKey"]){
+            const keydownEvent = new KeyboardEvent('keydown', {
+                keyCode: 27
+            });
+            document.dispatchEvent(keydownEvent);
+            document.querySelector('[jsname="NSjDf"]').click();
+        }
     }
   });
+
 
   code = code.replaceAll(/\$\$/gm, `doubleD`)
   code = code.replaceAll(/\$\&/gm, `$ &`)


### PR DESCRIPTION
used the local storage to properly store the keybind settings
made the default (if no previous local storage values for keybinds) be Shift
made it so that the reset key is not triggered when you are in a menu of any kind
<img width="391" height="243" alt="Screenshot 2025-09-20 094738" src="https://github.com/user-attachments/assets/051162cc-68b2-43e6-98cd-219ad4385047" />
